### PR TITLE
Update Sakuracloud APIs. Fix ( #5 , #9 )

### DIFF
--- a/resource_sakuracloud_dns_record_test.go
+++ b/resource_sakuracloud_dns_record_test.go
@@ -104,6 +104,37 @@ func TestAccSakuraCloudDNSRecord_With_Count(t *testing.T) {
 	})
 }
 
+func TestAccSakuraCloudDNSRecord_With_SRV(t *testing.T) {
+	var dns sacloud.DNS
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSakuraCloudDNSRecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckSakuraCloudDNSRecordConfig_srv,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSakuraCloudDNSExists("sakuracloud_dns.foobar", &dns),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_dns.foobar", "zone", "terraform.io"),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_dns_record.foobar1", "name", "_sip._tls"),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_dns_record.foobar1", "type", "SRV"),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_dns_record.foobar1", "value", "www.sakura.ne.jp."),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_dns_record.foobar1", "priority", "1"),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_dns_record.foobar1", "weight", "2"),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_dns_record.foobar1", "port", "3"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckSakuraCloudDNSRecordDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*api.Client)
 
@@ -166,4 +197,20 @@ resource "sakuracloud_dns_record" "foobar" {
     name = "test"
     type = "A"
     value = "${element(split("," , var.ip_list),count.index)}"
+}`
+
+var testAccCheckSakuraCloudDNSRecordConfig_srv = `
+resource "sakuracloud_dns" "foobar" {
+    zone = "terraform.io"
+    description = "DNS from TerraForm for SAKURA CLOUD"
+    tags = ["hoge1"]
+}
+resource "sakuracloud_dns_record" "foobar1" {
+    dns_id = "${sakuracloud_dns.foobar.id}"
+    name = "_sip._tls"
+    type = "SRV"
+    value = "www.sakura.ne.jp."
+    priority = 1
+    weight = 2
+    port = 3
 }`

--- a/resource_sakuracloud_gslb.go
+++ b/resource_sakuracloud_gslb.go
@@ -70,6 +70,10 @@ func resourceSakuraCloudGSLB() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"sorry_server": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"description": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -119,6 +123,10 @@ func resourceSakuraCloudGSLBCreate(d *schema.ResourceData, meta interface{}) err
 		opts.Settings.GSLB.Weighted = "False"
 	}
 
+	if sorryServer, ok := d.GetOk("sorry_server"); ok {
+		opts.Settings.GSLB.SorryServer = sorryServer.(string)
+	}
+
 	if description, ok := d.GetOk("description"); ok {
 		opts.Description = description.(string)
 	}
@@ -161,6 +169,7 @@ func resourceSakuraCloudGSLBRead(d *schema.ResourceData, meta interface{}) error
 	healthCheck["delay_loop"] = gslb.Settings.GSLB.DelayLoop
 	d.Set("health_check", schema.NewSet(healthCheckHash, []interface{}{healthCheck}))
 
+	d.Set("sorry_server", gslb.Settings.GSLB.SorryServer)
 	d.Set("description", gslb.Description)
 	d.Set("tags", gslb.Tags)
 	d.Set("weighted", gslb.Settings.GSLB.Weighted == "True")
@@ -210,6 +219,14 @@ func resourceSakuraCloudGSLBUpdate(d *schema.ResourceData, meta interface{}) err
 		gslb.Settings.GSLB.Weighted = "True"
 	} else {
 		gslb.Settings.GSLB.Weighted = "False"
+	}
+
+	if d.HasChange("sorry_server") {
+		if sorryServer, ok := d.GetOk("sorry_server"); ok {
+			gslb.Settings.GSLB.SorryServer = sorryServer.(string)
+		} else {
+			gslb.Settings.GSLB.SorryServer = ""
+		}
 	}
 
 	if d.HasChange("description") {

--- a/resource_sakuracloud_gslb_server_test.go
+++ b/resource_sakuracloud_gslb_server_test.go
@@ -125,4 +125,5 @@ resource "sakuracloud_gslb_server" "foobar" {
     count = 4
     gslb_id = "${sakuracloud_gslb.foobar.id}"
     ipaddress = "${element(split("," , var.gslb_ip_list),count.index)}"
+
 }`

--- a/resource_sakuracloud_gslb_test.go
+++ b/resource_sakuracloud_gslb_test.go
@@ -23,6 +23,8 @@ func TestAccSakuraCloudGSLB_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"sakuracloud_gslb.foobar", "name", "terraform.io"),
 					resource.TestCheckResourceAttr(
+						"sakuracloud_gslb.foobar", "sorry_server", "8.8.8.8"),
+					resource.TestCheckResourceAttr(
 						"sakuracloud_gslb.foobar", "health_check.1802742300.protocol", "http"),
 					resource.TestCheckResourceAttr(
 						"sakuracloud_gslb.foobar", "health_check.1802742300.delay_loop", "10"),
@@ -48,6 +50,8 @@ func TestAccSakuraCloudGSLB_Update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"sakuracloud_gslb.foobar", "name", "terraform.io"),
 					resource.TestCheckResourceAttr(
+						"sakuracloud_gslb.foobar", "sorry_server", "8.8.8.8"),
+					resource.TestCheckResourceAttr(
 						"sakuracloud_gslb.foobar", "health_check.1802742300.protocol", "http"),
 					resource.TestCheckResourceAttr(
 						"sakuracloud_gslb.foobar", "health_check.1802742300.delay_loop", "10"),
@@ -62,6 +66,8 @@ func TestAccSakuraCloudGSLB_Update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"sakuracloud_gslb.foobar", "name", "terraform.io"),
 					resource.TestCheckResourceAttr(
+						"sakuracloud_gslb.foobar", "sorry_server", "8.8.4.4"),
+					resource.TestCheckResourceAttr(
 						"sakuracloud_gslb.foobar", "health_check.755645870.protocol", "https"),
 					resource.TestCheckResourceAttr(
 						"sakuracloud_gslb.foobar", "health_check.755645870.delay_loop", "20"),
@@ -75,6 +81,8 @@ func TestAccSakuraCloudGSLB_Update(t *testing.T) {
 					testAccCheckSakuraCloudGSLBExists("sakuracloud_gslb.foobar", &gslb),
 					resource.TestCheckResourceAttr(
 						"sakuracloud_gslb.foobar", "name", "terraform.io"),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_gslb.foobar", "sorry_server", "8.8.4.4"),
 					resource.TestCheckResourceAttr(
 						"sakuracloud_gslb.foobar", "health_check.755645870.protocol", "https"),
 					resource.TestCheckResourceAttr(
@@ -145,6 +153,7 @@ resource "sakuracloud_gslb" "foobar" {
         path = "/"
         status = "200"
     }
+    sorry_server = "8.8.8.8"
     description = "GSLB from TerraForm for SAKURA CLOUD"
     tags = ["hoge1", "hoge2"]
 }`
@@ -159,6 +168,7 @@ resource "sakuracloud_gslb" "foobar" {
         path = "/"
         status = "200"
     }
+    sorry_server = "8.8.4.4"
     description = "GSLB from TerraForm for SAKURA CLOUD"
     tags = ["hoge1", "hoge2"]
 }`
@@ -173,6 +183,7 @@ resource "sakuracloud_gslb" "foobar" {
         path = "/"
         status = "200"
     }
+    sorry_server = "8.8.4.4"
     description = "GSLB from TerraForm for SAKURA CLOUD"
     tags = ["hoge1", "hoge2"]
 }`

--- a/resource_sakuracloud_simple_monitor_test.go
+++ b/resource_sakuracloud_simple_monitor_test.go
@@ -22,9 +22,11 @@ func TestAccSakuraCloudSimpleMonitor_Basic(t *testing.T) {
 					testAccCheckSakuraCloudSimpleMonitorExists("sakuracloud_simple_monitor.foobar", &monitor),
 					testAccCheckSakuraCloudSimpleMonitorAttributes(&monitor),
 					resource.TestCheckResourceAttr(
-						"sakuracloud_simple_monitor.foobar", "health_check.1245524278.protocol", "http"),
+						"sakuracloud_simple_monitor.foobar", "health_check.109142589.protocol", "http"),
 					resource.TestCheckResourceAttr(
-						"sakuracloud_simple_monitor.foobar", "health_check.1245524278.delay_loop", "60"),
+						"sakuracloud_simple_monitor.foobar", "health_check.109142589.delay_loop", "60"),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_simple_monitor.foobar", "health_check.109142589.host_header", "libsacloud.com"),
 					resource.TestCheckResourceAttr(
 						"sakuracloud_simple_monitor.foobar", "target", "terraform.io"),
 					resource.TestCheckResourceAttr(
@@ -50,9 +52,9 @@ func TestAccSakuraCloudSimpleMonitor_Update(t *testing.T) {
 					testAccCheckSakuraCloudSimpleMonitorExists("sakuracloud_simple_monitor.foobar", &monitor),
 					testAccCheckSakuraCloudSimpleMonitorAttributes(&monitor),
 					resource.TestCheckResourceAttr(
-						"sakuracloud_simple_monitor.foobar", "health_check.1245524278.protocol", "http"),
+						"sakuracloud_simple_monitor.foobar", "health_check.109142589.protocol", "http"),
 					resource.TestCheckResourceAttr(
-						"sakuracloud_simple_monitor.foobar", "health_check.1245524278.delay_loop", "60"),
+						"sakuracloud_simple_monitor.foobar", "health_check.109142589.delay_loop", "60"),
 					resource.TestCheckResourceAttr(
 						"sakuracloud_simple_monitor.foobar", "target", "terraform.io"),
 					resource.TestCheckResourceAttr(
@@ -66,6 +68,8 @@ func TestAccSakuraCloudSimpleMonitor_Update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSakuraCloudSimpleMonitorExists("sakuracloud_simple_monitor.foobar", &monitor),
 					testAccCheckSakuraCloudSimpleMonitorAttributesUpdated(&monitor),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_simple_monitor.foobar", "health_check.1187190475.host_header", "libsacloud.com"),
 					resource.TestCheckResourceAttr(
 						"sakuracloud_simple_monitor.foobar", "target", "terraform.io"),
 					resource.TestCheckResourceAttr(
@@ -150,6 +154,7 @@ resource "sakuracloud_simple_monitor" "foobar" {
         delay_loop = 60
         path = "/"
         status = "200"
+        host_header = "libsacloud.com"
     }
     description = "SimpleMonitor from TerraForm for SAKURA CLOUD"
     tags = ["hoge1" , "hoge2"]
@@ -166,6 +171,7 @@ resource "sakuracloud_simple_monitor" "foobar" {
         delay_loop = 120
         path = "/"
         status = "200"
+        host_header = "libsacloud.com"
     }
     description = "SimpleMonitor from TerraForm for SAKURA CLOUD"
     tags = ["hoge1" , "hoge2"]

--- a/resource_sakuracloud_switch_test.go
+++ b/resource_sakuracloud_switch_test.go
@@ -83,10 +83,28 @@ func TestAccSakuraCloudSwitch_WithServer(t *testing.T) {
 	})
 }
 
+//func TestAccSakuraCloudSwitch_Import(t *testing.T) {
+//	resourceName := "sakuracloud_switch.foobar"
+//	resource.Test(t, resource.TestCase{
+//		PreCheck:     func() { testAccPreCheck(t) },
+//		Providers:    testAccProviders,
+//		CheckDestroy: testAccCheckSakuraCloudSwitchDestroy,
+//		Steps: []resource.TestStep{
+//			resource.TestStep{
+//				Config: testAccCheckSakuraCloudSwitchConfig_basic,
+//			},
+//			resource.TestStep{
+//				ResourceName:      resourceName,
+//				ImportState:       true,
+//				ImportStateVerify: true,
+//			},
+//		},
+//	})
+//}
+
 func testAccCheckSakuraCloudSwitchExists(n string, sw *sacloud.Switch) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
-
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}

--- a/vendor/github.com/yamamoto-febc/libsacloud/sacloud/dns.go
+++ b/vendor/github.com/yamamoto-febc/libsacloud/sacloud/dns.go
@@ -54,7 +54,7 @@ func CreateNewDNS(zoneName string) *DNS {
 }
 
 func AllowDNSTypes() []string {
-	return []string{"A", "AAAA", "CNAME", "NS", "MX", "TXT"}
+	return []string{"A", "AAAA", "CNAME", "NS", "MX", "TXT", "SRV"}
 }
 
 func (d *DNS) SetZone(zone string) {
@@ -81,6 +81,15 @@ func (d *DNS) CreateNewMXRecord(name string, rdata string, ttl int, priority int
 		Name:  name,
 		Type:  "MX",
 		RData: fmt.Sprintf("%d %s", priority, rdata),
+		TTL:   ttl,
+	}
+}
+
+func (d *DNS) CreateNewSRVRecord(name string, rdata string, ttl int, priority int, weight int, port int) *DNSRecordSet {
+	return &DNSRecordSet{
+		Name:  name,
+		Type:  "SRV",
+		RData: fmt.Sprintf("%d %d %d %s", priority, weight, port, rdata),
 		TTL:   ttl,
 	}
 }

--- a/vendor/github.com/yamamoto-febc/libsacloud/sacloud/gslb.go
+++ b/vendor/github.com/yamamoto-febc/libsacloud/sacloud/gslb.go
@@ -94,6 +94,7 @@ type GSLBRecordSets struct {
 	HealthCheck GSLBHealthCheck `json:",omitempty"`
 	Weighted    string          `json:",omitempty"`
 	Servers     []GSLBServer    `json:",omitempty"`
+	SorryServer string          `json:",omitempty"`
 }
 
 // AddServer Add server to GSLB

--- a/vendor/github.com/yamamoto-febc/libsacloud/sacloud/simple_monitor.go
+++ b/vendor/github.com/yamamoto-febc/libsacloud/sacloud/simple_monitor.go
@@ -51,6 +51,7 @@ type SimpleMonitorHealthCheck struct {
 	Port         string `json:",omitempty"`
 	Path         string `json:",omitempty"`
 	Status       string `json:",omitempty"`
+	Host         string `json:",omitempty"`
 	QName        string `json:",omitempty"`
 	ExpectedData string `json:",omitempty"`
 	Community    string `json:",omitempty"`
@@ -127,21 +128,23 @@ func (s *SimpleMonitor) SetHealthCheckTCP(port string) {
 	}
 }
 
-func (s *SimpleMonitor) SetHealthCheckHTTP(port string, path string, status string) {
+func (s *SimpleMonitor) SetHealthCheckHTTP(port string, path string, status string, host string) {
 	s.Settings.SimpleMonitor.HealthCheck = &SimpleMonitorHealthCheck{
 		Protocol: "http",
 		Port:     port,
 		Path:     path,
 		Status:   status,
+		Host:     host,
 	}
 }
 
-func (s *SimpleMonitor) SetHealthCheckHTTPS(port string, path string, status string) {
+func (s *SimpleMonitor) SetHealthCheckHTTPS(port string, path string, status string, host string) {
 	s.Settings.SimpleMonitor.HealthCheck = &SimpleMonitorHealthCheck{
 		Protocol: "https",
 		Port:     port,
 		Path:     path,
 		Status:   status,
+		Host:     host,
 	}
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -453,14 +453,14 @@
 		{
 			"checksumSHA1": "qG5hjVNqqZO+kU1C02YtMxn//Vk=",
 			"path": "github.com/yamamoto-febc/libsacloud/api",
-			"revision": "8874fff08c8180d1de2c9a816fdc1ea02a59298e",
-			"revisionTime": "2016-06-23T07:19:55Z"
+			"revision": "3d12397cc3012c08dfe108a4a4e6819845dda126",
+			"revisionTime": "2016-06-30T06:34:29Z"
 		},
 		{
-			"checksumSHA1": "vaggfVRGHotR3olHhQ5h19XqKTA=",
+			"checksumSHA1": "puomdf3H5l3JAQN1w0eiFE/S7hs=",
 			"path": "github.com/yamamoto-febc/libsacloud/sacloud",
-			"revision": "8874fff08c8180d1de2c9a816fdc1ea02a59298e",
-			"revisionTime": "2016-06-23T07:19:55Z"
+			"revision": "3d12397cc3012c08dfe108a4a4e6819845dda126",
+			"revisionTime": "2016-06-30T06:34:29Z"
 		}
 	],
 	"rootPath": "github.com/yamamoto-febc/terraform-provider-sakuracloud"


### PR DESCRIPTION
- シンプル監視HTTP/HTTPSでのポート指定
- GSLBへのソーリーサーバー指定
- DNSでのSRVレコード追加
- シンプル監視でのHOSTヘッダ指定