### PR TITLE
IPアドレスの手動設定に対応

### DIFF
--- a/builtin/providers/sakuracloud/resource_sakuracloud_disk.go
+++ b/builtin/providers/sakuracloud/resource_sakuracloud_disk.go
@@ -103,6 +103,18 @@ func resourceSakuraCloudDisk() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+			"user_ip_address": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"default_route": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"network_mask_len": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
 			"note_ids": &schema.Schema{
 				Type:     schema.TypeList,
 				Optional: true,
@@ -176,6 +188,18 @@ func resourceSakuraCloudDiskCreate(d *schema.ResourceData, meta interface{}) err
 		diskEditCondig.SetNotes(ids)
 	}
 
+	if userIPAddress, ok := d.GetOk("user_ip_address"); ok {
+		diskEditCondig.SetUserIPAddress(userIPAddress.(string))
+	}
+
+	if defaultRoute, ok := d.GetOk("default_route"); ok {
+		diskEditCondig.SetDefaultRoute(defaultRoute.(string))
+	}
+
+	if networkMaskLen, ok := d.GetOk("network_mask_len"); ok {
+		diskEditCondig.SetNetworkMaskLen(fmt.Sprint(networkMaskLen.(int)))
+	}
+
 	// call disk edit API
 	_, err = client.Disk.Config(disk.ID, diskEditCondig)
 	if err != nil {
@@ -241,7 +265,7 @@ func resourceSakuraCloudDiskUpdate(d *schema.ResourceData, meta interface{}) err
 	isRunning := disk.Server != nil && disk.Server.Instance.IsUp()
 	isDiskConfigChanged := false
 
-	if d.HasChange("passowrd") || d.HasChange("ssh_key_ids") || d.HasChange("disable_pw_auth") || d.HasChange("note_ids") {
+	if d.HasChange("passowrd") || d.HasChange("ssh_key_ids") || d.HasChange("disable_pw_auth") || d.HasChange("note_ids") || d.HasChange("user_ip_address") || d.HasChange("default_route") || d.HasChange("network_mask_len") {
 		isDiskConfigChanged = true
 	}
 
@@ -286,6 +310,12 @@ func resourceSakuraCloudDiskUpdate(d *schema.ResourceData, meta interface{}) err
 
 		if d.HasChange("disable_pw_auth") {
 			diskEditCondig.SetDisablePWAuth(d.Get("disable_pw_auth").(bool))
+		}
+
+		if d.HasChange("user_ip_address") || d.HasChange("default_route") || d.HasChange("network_mask_len") {
+			diskEditCondig.SetUserIPAddress(d.Get("user_ip_address").(string))
+			diskEditCondig.SetDefaultRoute(d.Get("default_route").(string))
+			diskEditCondig.SetNetworkMaskLen(fmt.Sprint(d.Get("network_mask_len").(int)))
 		}
 
 		if d.HasChange("note_ids") {

--- a/docs/configuration/resources/disk.md
+++ b/docs/configuration/resources/disk.md
@@ -31,6 +31,9 @@ resource "sakuracloud_disk" "disk01"{
 | `password`        | -   | パスワード               | - | 文字列 | ディスク修正機能で設定されるOS管理者パスワード [注2](#注2)|
 | `ssh_key_ids`     | -   | SSH公開鍵ID             | - | リスト(文字列) | ディスク修正機能で設定されるSSH認証用の公開鍵ID [注2](#注2)|
 | `disable_pw_auth` | -   | パスワードでの認証無効化   | - | `true`<br />`false` | SSH接続でのパスワード/チャレンジレスポンス認証の無効化 [注2](#注2)|
+| `user_ip_address` | -   | IPアドレス | - | 文字列 | eth0のIPアドレス [注2](#注2)|
+| `default_route`   | -   | デフォルトゲートウェイ | - | 文字列 | eth0のデフォルトゲートウェイ（user_ip_addressと同時指定時のみ有効） [注2](#注2)|
+| `network_mask_len`| -   | ネットワークマスク長 | - | 数値 | eth0のネットワークマスク長（user_ip_addressと同時指定時のみ有効） [注2](#注2)|
 | `note_ids`        | -   | スタートアップスクリプトID | - | リスト(文字列) | スタートアップスクリプトのID |
 | `description`     | -   | 説明  | - | 文字列 | - |
 | `tags`            | -   | タグ | - | リスト(文字列) | - |
@@ -63,6 +66,9 @@ OSによりディスク修正機能に対応していない場合があります
 | `password`          | パスワード               | -                                          |
 | `ssh_key_ids`       | SSH公開鍵ID             | -                                          |
 | `disable_pw_auth`   | パスワードでの認証無効化   | -                                          |
+| `user_ip_address`   | IPアドレス                 | -                                          |
+| `default_route`     | デフォルトゲートウェイ     | -                                          |
+| `network_mask_len`  | ネットワークマスク長       | -                                          |
 | `note_ids`          | スタートアップスクリプトID | -                                          |
 | `description`       | 説明                    | -                                          |
 | `tags`              | タグ                    | -                                          |


### PR DESCRIPTION
ディスクの修正で IP アドレスの手動設定ができるようにします。

```tf
resource "sakuracloud_switch" "myswitch" {
    name = "myswitch"
    description = "Switch from terraform for SAKURA CLOUD"
}

data sakuracloud_archive "centos" {
    filter = {
        name   = "Tags"
        values = ["current-stable", "arch-64bit", "distro-centos"]
    }
}

resource "sakuracloud_disk" "disk01"{
    name = "disk01"
    source_archive_id = "${data.sakuracloud_archive.centos.id}"
    disable_pw_auth = false
    user_ip_address = "192.168.0.3"
    default_route = "192.168.0.1"
    network_mask_len = 24
}

resource "sakuracloud_server" "myserver" {
    name = "myserver"
    disks = ["${sakuracloud_disk.disk01.id}"]
    base_interface = "${sakuracloud_switch.myswitch.id}"
    description = "Server from TerraForm for SAKURA CLOUD"
    tags = ["@virtio-net-pci"]
}
```

コントロールパネル上での以下の内容に相当します。

![2016-08-16 15 08 49](https://cloud.githubusercontent.com/assets/16922/17689538/8193275a-63c3-11e6-942b-482a19efc12c.png)
