### PR TITLE
Refactoring acc-test

### DIFF
--- a/builtin/providers/sakuracloud/resource_sakuracloud_auto_backup_test.go
+++ b/builtin/providers/sakuracloud/resource_sakuracloud_auto_backup_test.go
@@ -9,36 +9,7 @@ import (
 	"testing"
 )
 
-func TestAccResourceSakuraCloudAutoBackup_Basic(t *testing.T) {
-	var autoBackup sacloud.AutoBackup
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSakuraCloudAutoBackupDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccCheckSakuraCloudAutoBackupConfig_basic,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSakuraCloudAutoBackupExists("sakuracloud_auto_backup.foobar", &autoBackup),
-					resource.TestCheckResourceAttr("sakuracloud_auto_backup.foobar", "name", "name_before"),
-					resource.TestCheckResourceAttr("sakuracloud_auto_backup.foobar", "backup_hour", "0"),
-					resource.TestCheckResourceAttr("sakuracloud_auto_backup.foobar", "weekdays.#", "3"),
-					resource.TestCheckResourceAttr("sakuracloud_auto_backup.foobar", "weekdays.0", "mon"),
-					resource.TestCheckResourceAttr("sakuracloud_auto_backup.foobar", "weekdays.1", "tue"),
-					resource.TestCheckResourceAttr("sakuracloud_auto_backup.foobar", "weekdays.2", "wed"),
-					resource.TestCheckResourceAttr("sakuracloud_auto_backup.foobar", "max_backup_num", "1"),
-					resource.TestCheckResourceAttr("sakuracloud_auto_backup.foobar", "description", "description_before"),
-					resource.TestCheckResourceAttr("sakuracloud_auto_backup.foobar", "tags.#", "2"),
-					resource.TestCheckResourceAttr("sakuracloud_auto_backup.foobar", "tags.0", "hoge1"),
-					resource.TestCheckResourceAttr("sakuracloud_auto_backup.foobar", "tags.1", "hoge2"),
-					resource.TestCheckResourceAttr("sakuracloud_auto_backup.foobar", "zone", "tk1a"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccResourceSakuraCloudAutoBackup_Update(t *testing.T) {
+func TestAccResourceSakuraCloudAutoBackup(t *testing.T) {
 	var autoBackup sacloud.AutoBackup
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/builtin/providers/sakuracloud/resource_sakuracloud_bridge_test.go
+++ b/builtin/providers/sakuracloud/resource_sakuracloud_bridge_test.go
@@ -9,55 +9,7 @@ import (
 	"testing"
 )
 
-func TestAccResourceSakuraCloudBridge_Basic(t *testing.T) {
-	var bridge sacloud.Bridge
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSakuraCloudBridgeDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccCheckSakuraCloudBridgeConfig_basic,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSakuraCloudBridgeExists("sakuracloud_bridge.foobar", &bridge),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_bridge.foobar", "name", "mybridge"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_bridge.foobar", "switch_ids.#", "0"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccResourceSakuraCloudBridge_Update(t *testing.T) {
-	var bridge sacloud.Bridge
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSakuraCloudBridgeDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccCheckSakuraCloudBridgeConfig_basic,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSakuraCloudBridgeExists("sakuracloud_bridge.foobar", &bridge),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_bridge.foobar", "name", "mybridge"),
-				),
-			},
-			resource.TestStep{
-				Config: testAccCheckSakuraCloudBridgeConfig_update,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSakuraCloudBridgeExists("sakuracloud_bridge.foobar", &bridge),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_bridge.foobar", "name", "mybridge_upd"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccResourceSakuraCloudBridge_WithSwitch(t *testing.T) {
+func TestAccResourceSakuraCloudBridge(t *testing.T) {
 	var bridge sacloud.Bridge
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -156,27 +108,12 @@ func testAccCheckSakuraCloudBridgeDestroy(s *terraform.State) error {
 	return nil
 }
 
-var testAccCheckSakuraCloudBridgeConfig_basic = `
-resource "sakuracloud_bridge" "foobar" {
-    name = "mybridge"
-    description = "Bridge from TerraForm for SAKURA CLOUD"
-    zone = "is1b"
-}`
-
-var testAccCheckSakuraCloudBridgeConfig_update = `
-resource "sakuracloud_bridge" "foobar" {
-    name = "mybridge_upd"
-    description = "Bridge from TerraForm for SAKURA CLOUD"
-    zone = "is1b"
-}`
-
 var testAccCheckSakuraCloudBridgeConfig_withSwitch = `
 resource "sakuracloud_switch" "foobar" {
     name = "myswitch"
     description = "Switch from TerraForm for SAKURA CLOUD"
     zone = "is1b"
     bridge_id = "${sakuracloud_bridge.foobar.id}"
-    depends_on = ["sakuracloud_bridge.foobar"]
 }
 resource "sakuracloud_bridge" "foobar" {
     name = "mybridge"
@@ -189,7 +126,6 @@ resource "sakuracloud_switch" "foobar" {
     name = "myswitch_upd"
     description = "Switch from TerraForm for SAKURA CLOUD"
     zone = "is1b"
-    depends_on = ["sakuracloud_bridge.foobar"]
 }
 resource "sakuracloud_bridge" "foobar" {
     name = "mybridge_upd"

--- a/builtin/providers/sakuracloud/resource_sakuracloud_database_test.go
+++ b/builtin/providers/sakuracloud/resource_sakuracloud_database_test.go
@@ -9,44 +9,7 @@ import (
 	"testing"
 )
 
-func TestAccResourceSakuraCloudDatabase_Basic(t *testing.T) {
-	var database sacloud.Database
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSakuraCloudDatabaseDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccCheckSakuraCloudDatabaseConfig_basic,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSakuraCloudDatabaseExists("sakuracloud_database.foobar", &database),
-					resource.TestCheckResourceAttr("sakuracloud_database.foobar", "name", "name_before"),
-					resource.TestCheckResourceAttr("sakuracloud_database.foobar", "description", "description_before"),
-					resource.TestCheckResourceAttr("sakuracloud_database.foobar", "tags.#", "2"),
-					resource.TestCheckResourceAttr("sakuracloud_database.foobar", "tags.0", "hoge1"),
-					resource.TestCheckResourceAttr("sakuracloud_database.foobar", "tags.1", "hoge2"),
-					//resource.TestCheckResourceAttr("sakuracloud_database.foobar", "plan", "mini"),
-					//resource.TestCheckResourceAttr("sakuracloud_database.foobar", "is_double", "false"),
-					resource.TestCheckResourceAttr("sakuracloud_database.foobar", "admin_password", "DatabasePasswordAdmin397"),
-					resource.TestCheckResourceAttr("sakuracloud_database.foobar", "user_name", "defuser"),
-					resource.TestCheckResourceAttr("sakuracloud_database.foobar", "user_password", "DatabasePasswordUser397"),
-					resource.TestCheckResourceAttr("sakuracloud_database.foobar", "allow_networks.#", "2"),
-					resource.TestCheckResourceAttr("sakuracloud_database.foobar", "allow_networks.0", "192.168.11.0/24"),
-					resource.TestCheckResourceAttr("sakuracloud_database.foobar", "allow_networks.1", "192.168.12.0/24"),
-					resource.TestCheckResourceAttr("sakuracloud_database.foobar", "port", "54321"),
-					resource.TestCheckResourceAttr("sakuracloud_database.foobar", "backup_rotate", "8"),
-					resource.TestCheckResourceAttr("sakuracloud_database.foobar", "backup_time", "00:00"),
-					resource.TestCheckResourceAttr("sakuracloud_database.foobar", "switch_id", "shared"),
-					//resource.TestCheckResourceAttr("sakuracloud_database.foobar", "ipaddress1", ""),
-					resource.TestCheckResourceAttr("sakuracloud_database.foobar", "nw_mask_len", "0"),
-					resource.TestCheckResourceAttr("sakuracloud_database.foobar", "default_route", ""),
-				),
-			},
-		},
-	})
-}
-
-func TestAccResourceSakuraCloudDatabase_Update(t *testing.T) {
+func TestAccSakuraCloudDatabase_Basic(t *testing.T) {
 	var database sacloud.Database
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -136,6 +99,31 @@ func TestAccResourceSakuraCloudDatabase_WithSwitch(t *testing.T) {
 					resource.TestCheckResourceAttr("sakuracloud_database.foobar", "port", "54321"),
 					resource.TestCheckResourceAttr("sakuracloud_database.foobar", "backup_rotate", "8"),
 					resource.TestCheckResourceAttr("sakuracloud_database.foobar", "backup_time", "00:00"),
+					resource.TestCheckResourceAttr("sakuracloud_database.foobar", "ipaddress1", "192.168.11.101"),
+					resource.TestCheckResourceAttr("sakuracloud_database.foobar", "nw_mask_len", "24"),
+					resource.TestCheckResourceAttr("sakuracloud_database.foobar", "default_route", "192.168.11.1"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckSakuraCloudDatabaseConfig_WithSwitchUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSakuraCloudDatabaseExists("sakuracloud_database.foobar", &database),
+					resource.TestCheckResourceAttr("sakuracloud_database.foobar", "name", "name_after"),
+					resource.TestCheckResourceAttr("sakuracloud_database.foobar", "description", "description_after"),
+					resource.TestCheckResourceAttr("sakuracloud_database.foobar", "tags.#", "2"),
+					resource.TestCheckResourceAttr("sakuracloud_database.foobar", "tags.0", "hoge1_after"),
+					resource.TestCheckResourceAttr("sakuracloud_database.foobar", "tags.1", "hoge2_after"),
+					//resource.TestCheckResourceAttr("sakuracloud_database.foobar", "plan", "mini"),
+					//resource.TestCheckResourceAttr("sakuracloud_database.foobar", "is_double", "false"),
+					resource.TestCheckResourceAttr("sakuracloud_database.foobar", "admin_password", "DatabasePasswordAdmin397"),
+					resource.TestCheckResourceAttr("sakuracloud_database.foobar", "user_name", "defuser"),
+					resource.TestCheckResourceAttr("sakuracloud_database.foobar", "user_password", "DatabasePasswordUser397_upd"),
+					resource.TestCheckResourceAttr("sakuracloud_database.foobar", "allow_networks.#", "2"),
+					resource.TestCheckResourceAttr("sakuracloud_database.foobar", "allow_networks.0", "192.168.110.0/24"),
+					resource.TestCheckResourceAttr("sakuracloud_database.foobar", "allow_networks.1", "192.168.120.0/24"),
+					resource.TestCheckResourceAttr("sakuracloud_database.foobar", "port", "54322"),
+					resource.TestCheckResourceAttr("sakuracloud_database.foobar", "backup_rotate", "7"),
+					resource.TestCheckResourceAttr("sakuracloud_database.foobar", "backup_time", "00:30"),
 					resource.TestCheckResourceAttr("sakuracloud_database.foobar", "ipaddress1", "192.168.11.101"),
 					resource.TestCheckResourceAttr("sakuracloud_database.foobar", "nw_mask_len", "24"),
 					resource.TestCheckResourceAttr("sakuracloud_database.foobar", "default_route", "192.168.11.1"),
@@ -265,5 +253,35 @@ resource "sakuracloud_database" "foobar" {
     name = "name_before"
     description = "description_before"
     tags = ["hoge1" , "hoge2"]
+    zone = "tk1a"
+}`
+
+const testAccCheckSakuraCloudDatabaseConfig_WithSwitchUpdate = `
+resource "sakuracloud_switch" "sw" {
+    name = "sw"
+    zone = "tk1a"
+}
+resource "sakuracloud_database" "foobar" {
+
+    admin_password = "DatabasePasswordAdmin397"
+    user_name = "defuser"
+    user_password = "DatabasePasswordUser397_upd"
+
+    allow_networks = ["192.168.110.0/24","192.168.120.0/24"]
+
+    port = 54322
+
+    backup_rotate = 7
+    backup_time = "00:30"
+
+    name = "name_after"
+    description = "description_after"
+    tags = ["hoge1_after" , "hoge2_after"]
+
+    switch_id = "${sakuracloud_switch.sw.id}"
+    ipaddress1 = "192.168.11.101"
+    nw_mask_len = 24
+    default_route = "192.168.11.1"
+
     zone = "tk1a"
 }`

--- a/builtin/providers/sakuracloud/resource_sakuracloud_disk_test.go
+++ b/builtin/providers/sakuracloud/resource_sakuracloud_disk_test.go
@@ -9,29 +9,7 @@ import (
 	"testing"
 )
 
-func TestAccResourceSakuraCloudDisk_Basic(t *testing.T) {
-	var disk sacloud.Disk
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSakuraCloudDiskDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccCheckSakuraCloudDiskConfig_basic,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSakuraCloudDiskExists("sakuracloud_disk.foobar", &disk),
-					testAccCheckSakuraCloudDiskAttributes(&disk),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_disk.foobar", "name", "mydisk"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_disk.foobar", "disable_pw_auth", ""),
-				),
-			},
-		},
-	})
-}
-
-func TestAccResourceSakuraCloudDisk_Update(t *testing.T) {
+func TestAccResourceSakuraCloudDisk(t *testing.T) {
 	var disk sacloud.Disk
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/builtin/providers/sakuracloud/resource_sakuracloud_dns_test.go
+++ b/builtin/providers/sakuracloud/resource_sakuracloud_dns_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-func TestAccResourceSakuraCloudDNS_Basic(t *testing.T) {
+func TestAccResourceSakuraCloudDNS(t *testing.T) {
 	var dns sacloud.DNS
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -22,25 +22,8 @@ func TestAccResourceSakuraCloudDNS_Basic(t *testing.T) {
 					testAccCheckSakuraCloudDNSExists("sakuracloud_dns.foobar", &dns),
 					resource.TestCheckResourceAttr(
 						"sakuracloud_dns.foobar", "zone", "terraform.io"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccResourceSakuraCloudDNS_Update(t *testing.T) {
-	var dns sacloud.DNS
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSakuraCloudDNSDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccCheckSakuraCloudDNSConfig_basic,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSakuraCloudDNSExists("sakuracloud_dns.foobar", &dns),
 					resource.TestCheckResourceAttr(
-						"sakuracloud_dns.foobar", "zone", "terraform.io"),
+						"sakuracloud_dns.foobar", "description", "DNS from TerraForm for SAKURA CLOUD"),
 				),
 			},
 			resource.TestStep{
@@ -49,6 +32,8 @@ func TestAccResourceSakuraCloudDNS_Update(t *testing.T) {
 					testAccCheckSakuraCloudDNSExists("sakuracloud_dns.foobar", &dns),
 					resource.TestCheckResourceAttr(
 						"sakuracloud_dns.foobar", "zone", "terraform.io"),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_dns.foobar", "description", "DNS from TerraForm for SAKURA CLOUD_upd"),
 				),
 			},
 		},

--- a/builtin/providers/sakuracloud/resource_sakuracloud_gslb_server_test.go
+++ b/builtin/providers/sakuracloud/resource_sakuracloud_gslb_server_test.go
@@ -9,28 +9,7 @@ import (
 	"testing"
 )
 
-func TestAccResourceSakuraCloudGSLBServer_Basic(t *testing.T) {
-	var gslb sacloud.GSLB
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSakuraCloudGSLBServerDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccCheckSakuraCloudGSLBServerConfig_basic,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSakuraCloudGSLBExists("sakuracloud_gslb.foobar", &gslb),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_gslb_server.foobar.0", "ipaddress", "8.8.8.8"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_gslb_server.foobar.1", "ipaddress", "8.8.4.4"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccResourceSakuraCloudGSLBServer_Update(t *testing.T) {
+func TestAccResourceSakuraCloudGSLBServer(t *testing.T) {
 	var gslb sacloud.GSLB
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/builtin/providers/sakuracloud/resource_sakuracloud_gslb_test.go
+++ b/builtin/providers/sakuracloud/resource_sakuracloud_gslb_test.go
@@ -9,34 +9,7 @@ import (
 	"testing"
 )
 
-func TestAccResourceSakuraCloudGSLB_Basic(t *testing.T) {
-	var gslb sacloud.GSLB
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSakuraCloudGSLBDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccCheckSakuraCloudGSLBConfig_basic,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSakuraCloudGSLBExists("sakuracloud_gslb.foobar", &gslb),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_gslb.foobar", "name", "terraform.io"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_gslb.foobar", "sorry_server", "8.8.8.8"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_gslb.foobar", "health_check.1802742300.protocol", "http"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_gslb.foobar", "health_check.1802742300.delay_loop", "10"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_gslb.foobar", "health_check.1802742300.host_header", "terraform.io"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccResourceSakuraCloudGSLB_Update(t *testing.T) {
+func TestAccResourceSakuraCloudGSLB(t *testing.T) {
 	var gslb sacloud.GSLB
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/builtin/providers/sakuracloud/resource_sakuracloud_internet_test.go
+++ b/builtin/providers/sakuracloud/resource_sakuracloud_internet_test.go
@@ -9,34 +9,7 @@ import (
 	"testing"
 )
 
-func TTestAccResourceSakuraCloudInternet_Basic(t *testing.T) {
-	var internet sacloud.Internet
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSakuraCloudInternetDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccCheckSakuraCloudInternetConfig_basic,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSakuraCloudInternetExists("sakuracloud_internet.foobar", &internet),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_internet.foobar", "name", "myinternet"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_internet.foobar", "nw_mask_len", "28"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_internet.foobar", "band_width", "100"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_internet.foobar", "server_ids.#", "0"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_internet.foobar", "nw_ipaddresses.#", "11"),
-				),
-			},
-		},
-	})
-}
-
-func TTestAccResourceSakuraCloudInternet_Update(t *testing.T) {
+func TestAccResourceSakuraCloudInternet(t *testing.T) {
 	var internet sacloud.Internet
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -75,43 +48,16 @@ func TTestAccResourceSakuraCloudInternet_Update(t *testing.T) {
 						"sakuracloud_internet.foobar", "nw_ipaddresses.#", "11"),
 				),
 			},
-		},
-	})
-}
-
-func TTestAccResourceSakuraCloudInternet_WithServer(t *testing.T) {
-	var internet sacloud.Internet
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSakuraCloudInternetDestroy,
-		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccCheckSakuraCloudInternetConfig_with_server,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSakuraCloudInternetExists("sakuracloud_internet.foobar", &internet),
 					resource.TestCheckResourceAttr(
-						"sakuracloud_internet.foobar", "name", "myinternet"),
+						"sakuracloud_internet.foobar", "name", "myinternet_upd"),
 					resource.TestCheckResourceAttr(
 						"sakuracloud_internet.foobar", "nw_mask_len", "28"),
 					resource.TestCheckResourceAttr(
-						"sakuracloud_internet.foobar", "band_width", "100"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_internet.foobar", "server_ids.#", "0"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_internet.foobar", "nw_ipaddresses.#", "11"),
-				),
-			},
-			resource.TestStep{
-				Config: testAccCheckSakuraCloudInternetConfig_with_server,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSakuraCloudInternetExists("sakuracloud_internet.foobar", &internet),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_internet.foobar", "name", "myinternet"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_internet.foobar", "nw_mask_len", "28"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_internet.foobar", "band_width", "100"),
+						"sakuracloud_internet.foobar", "band_width", "500"),
 					resource.TestCheckResourceAttr(
 						"sakuracloud_internet.foobar", "server_ids.#", "1"),
 					resource.TestCheckResourceAttr(
@@ -176,6 +122,27 @@ resource "sakuracloud_internet" "foobar" {
 }`
 
 var testAccCheckSakuraCloudInternetConfig_update = `
+resource "sakuracloud_server" "foobar" {
+    name = "myserver"
+    disks = ["${sakuracloud_disk.foobar.id}"]
+    description = "Server from TerraForm for SAKURA CLOUD"
+    tags = ["@virtio-net-pci"]
+    base_interface = "${sakuracloud_internet.foobar.switch_id}"
+    base_nw_ipaddress = "${sakuracloud_internet.foobar.nw_ipaddresses.0}"
+    base_nw_gateway = "${sakuracloud_internet.foobar.nw_gateway}"
+    base_nw_mask_len = "${sakuracloud_internet.foobar.nw_mask_len}"
+}
+data "sakuracloud_archive" "ubuntu" {
+    filter = {
+	name = "Name"
+	values = ["Ubuntu Server 16"]
+    }
+}
+resource "sakuracloud_disk" "foobar"{
+    name = "mydisk"
+    source_archive_id = "${data.sakuracloud_archive.ubuntu.id}"
+}
+
 resource "sakuracloud_internet" "foobar" {
     name = "myinternet_upd"
     band_width = 500
@@ -203,6 +170,7 @@ resource "sakuracloud_disk" "foobar"{
     source_archive_id = "${data.sakuracloud_archive.ubuntu.id}"
 }
 resource "sakuracloud_internet" "foobar" {
-    name = "myinternet"
+    name = "myinternet_upd"
+    band_width = 500
 }
 `

--- a/builtin/providers/sakuracloud/resource_sakuracloud_loadbalancer_server_test.go
+++ b/builtin/providers/sakuracloud/resource_sakuracloud_loadbalancer_server_test.go
@@ -9,41 +9,7 @@ import (
 	"testing"
 )
 
-func TestAccResourceSakuraCloudLoadBalancerServer_Basic(t *testing.T) {
-	var loadBalancer sacloud.LoadBalancer
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSakuraCloudLoadBalancerServerDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccCheckSakuraCloudLoadBalancerServerConfig_basic,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSakuraCloudLoadBalancerExists("sakuracloud_load_balancer.foobar", &loadBalancer),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_load_balancer_server.server01", "ipaddress", "192.168.11.51"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_load_balancer_server.server01", "check_protocol", "http"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_load_balancer_server.server01", "check_path", "/"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_load_balancer_server.server01", "check_status", "200"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_load_balancer_server.server01", "enabled", "true"),
-				),
-			},
-			resource.TestStep{
-				Config: testAccCheckSakuraCloudLoadBalancerServerConfig_basic,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"sakuracloud_load_balancer_vip.vip1", "servers.#", "1"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccResourceSakuraCloudLoadBalancerServer_Update(t *testing.T) {
+func TestAccResourceSakuraCloudLoadBalancerServer(t *testing.T) {
 	var loadBalancer sacloud.LoadBalancer
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/builtin/providers/sakuracloud/resource_sakuracloud_loadbalancer_test.go
+++ b/builtin/providers/sakuracloud/resource_sakuracloud_loadbalancer_test.go
@@ -9,34 +9,7 @@ import (
 	"testing"
 )
 
-func TestAccResourceSakuraCloudLoadBalancer_Basic(t *testing.T) {
-	var loadBalancer sacloud.LoadBalancer
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSakuraCloudLoadBalancerDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccCheckSakuraCloudLoadBalancerConfig_basic,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSakuraCloudLoadBalancerExists("sakuracloud_load_balancer.foobar", &loadBalancer),
-					resource.TestCheckResourceAttr("sakuracloud_load_balancer.foobar", "name", "name_before"),
-					resource.TestCheckResourceAttr("sakuracloud_load_balancer.foobar", "description", "description_before"),
-					resource.TestCheckResourceAttr("sakuracloud_load_balancer.foobar", "tags.#", "2"),
-					resource.TestCheckResourceAttr("sakuracloud_load_balancer.foobar", "tags.0", "hoge1"),
-					resource.TestCheckResourceAttr("sakuracloud_load_balancer.foobar", "tags.1", "hoge2"),
-					resource.TestCheckResourceAttr("sakuracloud_load_balancer.foobar", "VRID", "1"),
-					resource.TestCheckResourceAttr("sakuracloud_load_balancer.foobar", "ipaddress1", "192.168.11.101"),
-					resource.TestCheckResourceAttr("sakuracloud_load_balancer.foobar", "ipaddress2", ""),
-					resource.TestCheckResourceAttr("sakuracloud_load_balancer.foobar", "nw_mask_len", "24"),
-					resource.TestCheckResourceAttr("sakuracloud_load_balancer.foobar", "default_route", "192.168.11.1"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccResourceSakuraCloudLoadBalancer_Update(t *testing.T) {
+func TestAccSakuraCloudLoadBalancer(t *testing.T) {
 	var loadBalancer sacloud.LoadBalancer
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -79,7 +52,7 @@ func TestAccResourceSakuraCloudLoadBalancer_Update(t *testing.T) {
 	})
 }
 
-func TestAccResourceSakuraCloudLoadBalancer_WithRouter(t *testing.T) {
+func TestAccSakuraCloudLoadBalancer_WithRouter(t *testing.T) {
 	var loadBalancer sacloud.LoadBalancer
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/builtin/providers/sakuracloud/resource_sakuracloud_loadbalancer_vip_test.go
+++ b/builtin/providers/sakuracloud/resource_sakuracloud_loadbalancer_vip_test.go
@@ -9,36 +9,7 @@ import (
 	"testing"
 )
 
-func TestAccResourceSakuraCloudLoadBalancerVIP_Basic(t *testing.T) {
-	var loadBalancer sacloud.LoadBalancer
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSakuraCloudLoadBalancerVIPDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccCheckSakuraCloudLoadBalancerVIPConfig_basic,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSakuraCloudLoadBalancerExists("sakuracloud_load_balancer.foobar", &loadBalancer),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_load_balancer_vip.vip1", "vip", "192.168.11.201"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_load_balancer_vip.vip1", "port", "80"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_load_balancer_vip.vip1", "delay_loop", "100"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_load_balancer_vip.vip1", "sorry_server", "192.168.11.11"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_load_balancer_vip.vip1", "servers.#", "0"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_load_balancer_vip.vip2", "vip", "192.168.11.202"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccResourceSakuraCloudLoadBalancerVIP_Update(t *testing.T) {
+func TestAccSakuraCloudLoadBalancerVIP(t *testing.T) {
 	var loadBalancer sacloud.LoadBalancer
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/builtin/providers/sakuracloud/resource_sakuracloud_note_test.go
+++ b/builtin/providers/sakuracloud/resource_sakuracloud_note_test.go
@@ -9,30 +9,7 @@ import (
 	"testing"
 )
 
-func TestAccResourceSakuraCloudNote_Basic(t *testing.T) {
-	var note sacloud.Note
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSakuraCloudNoteDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccCheckSakuraCloudNoteConfig_basic,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSakuraCloudNoteExists("sakuracloud_note.foobar", &note),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_note.foobar", "name", "mynote"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_note.foobar", "content", "content"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_note.foobar", "tags.#", "2"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccResourceSakuraCloudNote_Update(t *testing.T) {
+func TestAccResourceSakuraCloudNote(t *testing.T) {
 	var note sacloud.Note
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/builtin/providers/sakuracloud/resource_sakuracloud_packet_filter_test.go
+++ b/builtin/providers/sakuracloud/resource_sakuracloud_packet_filter_test.go
@@ -9,38 +9,7 @@ import (
 	"testing"
 )
 
-func TestAccResourceSakuraCloudPacketFilter_Basic(t *testing.T) {
-	var filter sacloud.PacketFilter
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSakuraCloudPacketFilterDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccCheckSakuraCloudPacketFilterConfig_basic,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSakuraCloudPacketFilterExists("sakuracloud_packet_filter.foobar", &filter),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_packet_filter.foobar", "name", "mypacket_filter"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_packet_filter.foobar", "expressions.#", "2"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_packet_filter.foobar", "expressions.0.protocol", "tcp"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_packet_filter.foobar", "expressions.0.source_nw", "0.0.0.0"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_packet_filter.foobar", "expressions.0.source_port", "0-65535"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_packet_filter.foobar", "expressions.0.dest_port", "80"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_packet_filter.foobar", "expressions.0.allow", "true"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccResourceSakuraCloudPacketFilter_Update(t *testing.T) {
+func TestAccResourceSakuraCloudPacketFilter(t *testing.T) {
 	var filter sacloud.PacketFilter
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/builtin/providers/sakuracloud/resource_sakuracloud_server_test.go
+++ b/builtin/providers/sakuracloud/resource_sakuracloud_server_test.go
@@ -9,37 +9,7 @@ import (
 	"testing"
 )
 
-func TestAccResourceSakuraCloudServer_Basic(t *testing.T) {
-	var server sacloud.Server
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSakuraCloudServerDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccCheckSakuraCloudServerConfig_basic,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSakuraCloudServerExists("sakuracloud_server.foobar", &server),
-					testAccCheckSakuraCloudServerAttributes(&server),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "core", "1"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "memory", "1"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "disks.#", "1"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "base_interface", "shared"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "additional_interfaces.#", "0"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "macaddresses.#", "1"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccResourceSakuraCloudServer_Update(t *testing.T) {
+func TestAccResourceSakuraCloudServer(t *testing.T) {
 	var server sacloud.Server
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -88,7 +58,7 @@ func TestAccResourceSakuraCloudServer_Update(t *testing.T) {
 	})
 }
 
-func TestAccResourceSakuraCloudServer_EditConnections(t *testing.T) {
+func TestAccSakuraCloudServer_EditConnections(t *testing.T) {
 	var server sacloud.Server
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -151,7 +121,7 @@ func TestAccResourceSakuraCloudServer_EditConnections(t *testing.T) {
 	})
 }
 
-func TestAccResourceSakuraCloudServer_ConnectPacketFilters(t *testing.T) {
+func TestAccSakuraCloudServer_ConnectPacketFilters(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/builtin/providers/sakuracloud/resource_sakuracloud_simple_monitor_test.go
+++ b/builtin/providers/sakuracloud/resource_sakuracloud_simple_monitor_test.go
@@ -9,37 +9,7 @@ import (
 	"testing"
 )
 
-func TestAccResourceSakuraCloudSimpleMonitor_Basic(t *testing.T) {
-	var monitor sacloud.SimpleMonitor
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSakuraCloudSimpleMonitorDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccCheckSakuraCloudSimpleMonitorConfig_basic,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSakuraCloudSimpleMonitorExists("sakuracloud_simple_monitor.foobar", &monitor),
-					testAccCheckSakuraCloudSimpleMonitorAttributes(&monitor),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_simple_monitor.foobar", "health_check.109142589.protocol", "http"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_simple_monitor.foobar", "health_check.109142589.delay_loop", "60"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_simple_monitor.foobar", "health_check.109142589.host_header", "libsacloud.com"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_simple_monitor.foobar", "target", "terraform.io"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_simple_monitor.foobar", "notify_slack_enabled", "true"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_simple_monitor.foobar", "notify_slack_webhook", testAccSlackWebhook),
-				),
-			},
-		},
-	})
-}
-
-func TestAccResourceSakuraCloudSimpleMonitor_Update(t *testing.T) {
+func TestAccResourceSakuraCloudSimpleMonitor(t *testing.T) {
 	var monitor sacloud.SimpleMonitor
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/builtin/providers/sakuracloud/resource_sakuracloud_ssh_key_test.go
+++ b/builtin/providers/sakuracloud/resource_sakuracloud_ssh_key_test.go
@@ -9,30 +9,7 @@ import (
 	"testing"
 )
 
-func TestAccResourceSakuraCloudSSHKey_Basic(t *testing.T) {
-	var ssh_key sacloud.SSHKey
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSakuraCloudSSHKeyDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccCheckSakuraCloudSSHKeyConfig_basic,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSakuraCloudSSHKeyExists("sakuracloud_ssh_key.foobar", &ssh_key),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_ssh_key.foobar", "name", "mykey"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_ssh_key.foobar", "public_key", testAccPublicKey),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_ssh_key.foobar", "fingerprint", testAccFingerprint),
-				),
-			},
-		},
-	})
-}
-
-func TestAccResourceSakuraCloudSSHKey_Update(t *testing.T) {
+func TestAccResourceSakuraCloudSSHKey(t *testing.T) {
 	var ssh_key sacloud.SSHKey
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/builtin/providers/sakuracloud/resource_sakuracloud_switch_test.go
+++ b/builtin/providers/sakuracloud/resource_sakuracloud_switch_test.go
@@ -9,28 +9,7 @@ import (
 	"testing"
 )
 
-func TestAccResourceSakuraCloudSwitch_Basic(t *testing.T) {
-	var sw sacloud.Switch
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSakuraCloudSwitchDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccCheckSakuraCloudSwitchConfig_basic,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSakuraCloudSwitchExists("sakuracloud_switch.foobar", &sw),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_switch.foobar", "name", "myswitch"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_switch.foobar", "server_ids.#", "0"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccResourceSakuraCloudSwitch_Update(t *testing.T) {
+func TestAccResourceSakuraCloudSwitch(t *testing.T) {
 	var sw sacloud.Switch
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -53,27 +32,8 @@ func TestAccResourceSakuraCloudSwitch_Update(t *testing.T) {
 						"sakuracloud_switch.foobar", "name", "myswitch_upd"),
 				),
 			},
-		},
-	})
-}
-
-func TestAccResourceSakuraCloudSwitch_WithServer(t *testing.T) {
-	var sw sacloud.Switch
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSakuraCloudSwitchDestroy,
-		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckSakuraCloudSwitchConfig_with_server,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSakuraCloudSwitchExists("sakuracloud_switch.foobar", &sw),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_switch.foobar", "name", "myswitch"),
-				),
-			},
-			resource.TestStep{
-				Config: testAccCheckSakuraCloudSwitchConfig_with_server,
+				Config: testAccCheckSakuraCloudSwitchConfig_update,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"sakuracloud_switch.foobar", "server_ids.#", "1"),
@@ -157,13 +117,6 @@ resource "sakuracloud_switch" "foobar" {
 }`
 
 var testAccCheckSakuraCloudSwitchConfig_update = `
-resource "sakuracloud_switch" "foobar" {
-    name = "myswitch_upd"
-    description = "Switch from TerraForm for SAKURA CLOUD"
-    tags = ["hoge1" , "hoge2"]
-}`
-
-var testAccCheckSakuraCloudSwitchConfig_with_server = `
 resource "sakuracloud_server" "foobar" {
     name = "myserver"
     description = "Server from TerraForm for SAKURA CLOUD"
@@ -171,7 +124,7 @@ resource "sakuracloud_server" "foobar" {
     additional_interfaces = ["${sakuracloud_switch.foobar.id}"]
 }
 resource "sakuracloud_switch" "foobar" {
-    name = "myswitch"
+    name = "myswitch_upd"
     description = "Switch from TerraForm for SAKURA CLOUD"
     tags = ["hoge1" , "hoge2"]
 }

--- a/builtin/providers/sakuracloud/resource_sakuracloud_vpc_router_test.go
+++ b/builtin/providers/sakuracloud/resource_sakuracloud_vpc_router_test.go
@@ -9,44 +9,7 @@ import (
 	"testing"
 )
 
-func TestAccResourceSakuraCloudVPCRouter_Basic(t *testing.T) {
-	var vpcRouter sacloud.VPCRouter
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSakuraCloudVPCRouterDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccCheckSakuraCloudVPCRouterConfig_basic,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSakuraCloudVPCRouterExists("sakuracloud_vpc_router.foobar", &vpcRouter),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_vpc_router.foobar", "name", "name_before"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_vpc_router.foobar", "description", "description_before"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_vpc_router.foobar", "tags.#", "2"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_vpc_router.foobar", "tags.0", "hoge1"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_vpc_router.foobar", "tags.1", "hoge2"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_vpc_router.foobar", "plan", "standard"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_vpc_router.foobar", "switch_id", ""),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_vpc_router.foobar", "vip", ""),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_vpc_router.foobar", "ipaddress1", ""),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_vpc_router.foobar", "ipaddress2", ""),
-				),
-			},
-		},
-	})
-}
-
-func TestAccResourceSakuraCloudVPCRouter_Update(t *testing.T) {
+func TestAccResourceSakuraCloudVPCRouter(t *testing.T) {
 	var vpcRouter sacloud.VPCRouter
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },


### PR DESCRIPTION
さくらのクラウドへのAPI呼び出しを実際に行うテスト`make testacc-resource`の
実行時間が40分を超えている。
このためTravisCIにてタイムアウトが発生する。

タイムアウトを防ぎ、PullRequest、push時両方でTravisCIのジョブを起動するようにしたい。