### PR TITLE
Don't set network parameters

### DIFF
--- a/builtin/providers/sakuracloud/resource_sakuracloud_server.go
+++ b/builtin/providers/sakuracloud/resource_sakuracloud_server.go
@@ -197,9 +197,6 @@ func resourceSakuraCloudServerCreate(d *schema.ResourceData, meta interface{}) e
 					isNeedEditDisk := false
 					diskEditConfig := client.Disk.NewCondig()
 					if server.Interfaces[0].Switch.Scope == sacloud.ESCopeShared {
-						diskEditConfig.SetUserIPAddress(server.Interfaces[0].IPAddress)
-						diskEditConfig.SetDefaultRoute(server.Interfaces[0].Switch.Subnet.DefaultRoute)
-						diskEditConfig.SetNetworkMaskLen(fmt.Sprintf("%d", server.Interfaces[0].Switch.Subnet.NetworkMaskLen))
 						isNeedEditDisk = true
 					} else {
 						baseIP := forceString(d.Get("base_nw_ipaddress"))
@@ -457,9 +454,6 @@ func resourceSakuraCloudServerUpdate(d *schema.ResourceData, meta interface{}) e
 			isNeedEditDisk := false
 			diskEditConfig := client.Disk.NewCondig()
 			if updatedServer.Interfaces[0].Switch.Scope == sacloud.ESCopeShared {
-				diskEditConfig.SetUserIPAddress(updatedServer.Interfaces[0].IPAddress)
-				diskEditConfig.SetDefaultRoute(updatedServer.Interfaces[0].Switch.Subnet.DefaultRoute)
-				diskEditConfig.SetNetworkMaskLen(fmt.Sprintf("%d", updatedServer.Interfaces[0].Switch.Subnet.NetworkMaskLen))
 				isNeedEditDisk = true
 			} else {
 				baseIP := forceString(d.Get("base_nw_ipaddress"))

--- a/builtin/providers/sakuracloud/resource_sakuracloud_server_test.go
+++ b/builtin/providers/sakuracloud/resource_sakuracloud_server_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/sacloud/libsacloud/api"
 	"github.com/sacloud/libsacloud/sacloud"
+	"regexp"
 	"testing"
 )
 
@@ -33,6 +34,9 @@ func TestAccResourceSakuraCloudServer(t *testing.T) {
 						"sakuracloud_server.foobar", "additional_interfaces.#", "0"),
 					resource.TestCheckResourceAttr(
 						"sakuracloud_server.foobar", "macaddresses.#", "1"),
+					resource.TestMatchResourceAttr("sakuracloud_server.foobar",
+						"base_nw_ipaddress",
+						regexp.MustCompile(".+")), // should be not empty
 				),
 			},
 			resource.TestStep{
@@ -52,6 +56,9 @@ func TestAccResourceSakuraCloudServer(t *testing.T) {
 						"sakuracloud_server.foobar", "additional_interfaces.#", "0"),
 					resource.TestCheckResourceAttr(
 						"sakuracloud_server.foobar", "macaddresses.#", "1"),
+					resource.TestMatchResourceAttr("sakuracloud_server.foobar",
+						"base_nw_ipaddress",
+						regexp.MustCompile(".+")), // should be not empty
 				),
 			},
 		},


### PR DESCRIPTION
To fix #97 
  - Don't set network parameters for DiskEdit API when server is connected to the shared segment.