### PR TITLE
Release version 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.8.0 (2017-04-06)
+
+* Don't set network parameters #98 (yamamoto-febc)
+* Remove backup_hour param #99 (yamamoto-febc)
+* Add database plans #100 (yamamoto-febc)
+
+
 ## 0.7.2 (2017-03-29)
 
 * Using CI pipelines is started (yamamoto-febc)


### PR DESCRIPTION
## Release version 0.8.0
- サーバー作成時のディスクの修正API呼び出しでの不要パラメータ除去 #98
- 自動バックアップでの開始時間パラメーター除去 #99
- データベースプラン(10g/30g/90g/240g)追加 #100

## 後方互換について
自動バックアップでの開始時間パラメーター除去(#99) は後方互換性のない修正です。  
`auto_backup`リソースで`backup_hour`パラメータを指定出来なくなりました。    
これまで`backup_hour`パラメータを利用していた場合、tfファイル/stateファイルの修正が必要です。
